### PR TITLE
Include branch name in output if exists

### DIFF
--- a/src/functions/check.js
+++ b/src/functions/check.js
@@ -45,6 +45,11 @@ export async function check(octokit, context) {
       // Set locked to true if the lock file exists
       core.info(FOUND_LOCK)
       core.setOutput('locked', 'true')
+
+      if (Object.prototype.hasOwnProperty.call(lockData, 'branch')) {
+        core.setOutput('branch', lockData['branch'])
+      }
+
       return true
     }
 


### PR DESCRIPTION
This PR updates the `check` mode of this action to output the branch that created the lock if it exists in the lock metadata.

This will be useful for unlocking on PR merges while doing a sanity check to make sure the merged branch created the lock.