### PR TITLE
Include lock metadata in output if present

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,12 @@ If you wish to use this Action via a comment on a pull request, simply omit the 
 | `type` | The type of trigger which was found - 'lock', 'unlock', or 'info-info-alias' |
 | `comment_body` | The comment body which triggered this action (if it was not headless) |
 | `headless` | The string "true" if the run was headless, otherwise the string "false" - Headless in this context would be if the "mode" was set and the Action was not invoked by a comment on a pull request |
-| `locked` | If the 'mode' is set to 'check', this output is exported to show if the lock is set in a headless run |
+| `locked` | If the "mode" is set to "check", this output is exported to show if the lock is set in a headless run |
 | `branch` | If the mode is set to "check", this output will be the branch name that holds the lock, otherwise it will be empty |
+| `created_by` | If the mode is set to "check", this output will be the user that holds the lock, otherwise it will be empty |
+| `created_at` | If the mode is set to "check", this output will be the ISO 8601 format date that the lock was claimed, otherwise it will be empty |
+| `reason` | If the mode is set to "check", this output will be the reason the deployment lock was claimed, otherwise it will be empty |
+| `link` | If the mode is set to "check", this output will be the link to the GitHub issue comment or action run that claimed the lock, otherwise it will be empty |
 | `global_lock_claimed` | The string "true" if the global lock was claimed |
 | `global_lock_released` | The string "true" if the global lock was released |
 | `lock_environment` | When running in headless mode and the "mode" is set to "check", this output will be the environment name that holds the lock, otherwise it will be empty |

--- a/__tests__/functions/check.test.js
+++ b/__tests__/functions/check.test.js
@@ -56,6 +56,19 @@ test('successfully checks for a production lock and finds a lock', async () => {
   expect(await check(octokit, context, environment)).toBe(true)
   expect(setOutputMock).toHaveBeenCalledWith('locked', 'true')
   expect(setOutputMock).toHaveBeenCalledWith('lock_environment', environment)
+  expect(setOutputMock).toHaveBeenCalledWith('created_by', 'octocat')
+  expect(setOutputMock).toHaveBeenCalledWith(
+    'created_at',
+    '2022-06-14T21:12:14.041Z'
+  )
+  expect(setOutputMock).toHaveBeenCalledWith(
+    'reason',
+    'Testing my new feature with lots of cats'
+  )
+  expect(setOutputMock).toHaveBeenCalledWith(
+    'link',
+    'https://github.com/test-org/test-repo/pull/2#issuecomment-456'
+  )
   expect(infoMock).toHaveBeenCalledWith('global lock does not exist')
   expect(infoMock).toHaveBeenCalledWith('production lock exists')
 })
@@ -81,6 +94,19 @@ test('successfully checks for a production lock and finds a global lock instead'
   expect(await check(octokit, context, environment)).toBe(true)
   expect(setOutputMock).toHaveBeenCalledWith('locked', 'true')
   expect(setOutputMock).toHaveBeenCalledWith('lock_environment', 'global')
+  expect(setOutputMock).toHaveBeenCalledWith('created_by', 'octocat')
+  expect(setOutputMock).toHaveBeenCalledWith(
+    'created_at',
+    '2022-06-14T21:12:14.041Z'
+  )
+  expect(setOutputMock).toHaveBeenCalledWith(
+    'reason',
+    'Testing my new feature with lots of cats'
+  )
+  expect(setOutputMock).toHaveBeenCalledWith(
+    'link',
+    'https://github.com/test-org/test-repo/pull/2#issuecomment-456'
+  )
   expect(infoMock).toHaveBeenCalledWith('global lock exists')
 })
 

--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,14 @@ outputs:
     description: When running in headless mode and the "mode" is set to "check", this output will be the environment name that holds the lock, otherwise it will be empty
   branch:
     description: 'If the mode is set to "check", this output will be the branch name that holds the lock, otherwise it will be empty'
+  created_by:
+    description: 'If the mode is set to "check", this output will be the user that holds the lock, otherwise it will be empty'
+  created_at:
+    description: 'If the mode is set to "check", this output will be the ISO 8601 format date that the lock was claimed, otherwise it will be empty'
+  reason:
+    description: 'If the mode is set to "check", this output will be the reason the deployment lock was claimed, otherwise it will be empty'
+  link:
+    description: 'If the mode is set to "check", this output will be the link to the GitHub issue comment or action run that claimed the lock, otherwise it will be empty'
   global_lock_claimed:
     description: 'The string "true" if the global lock was claimed'
   global_lock_released:

--- a/src/functions/checkLockFile.js
+++ b/src/functions/checkLockFile.js
@@ -47,6 +47,22 @@ export async function checkLockFile(octokit, context, branch) {
       core.setOutput('branch', lockData['branch'])
     }
 
+    if (Object.prototype.hasOwnProperty.call(lockData, 'created_by')) {
+      core.setOutput('created_by', lockData['created_by'])
+    }
+
+    if (Object.prototype.hasOwnProperty.call(lockData, 'created_at')) {
+      core.setOutput('created_at', lockData['created_at'])
+    }
+
+    if (Object.prototype.hasOwnProperty.call(lockData, 'reason')) {
+      core.setOutput('reason', lockData['reason'])
+    }
+
+    if (Object.prototype.hasOwnProperty.call(lockData, 'link')) {
+      core.setOutput('link', lockData['link'])
+    }
+
     return true
   } catch (error) {
     // If the lock file doesn't exist, return false


### PR DESCRIPTION
This PR updates the `check` mode of this action to output the following if they exist in the lock metadata:

- `created_by` - User who claimed the lock
- `created_at` - Date the lock was claimed
- `reason` - Original reason provided when claiming the lock
- `link` - Link to the GitHub Issue or GitHub Action run that claimed the lock

This is useful for scenarios such as outputting the lock information into the [GitHub Actions Job summary](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/) so that it's more visible for users.